### PR TITLE
Fix typo in list merge operator

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,7 +55,7 @@ with stdenv.lib; let
   yarnAlias     = ''yarn() { ${yarnCmd} $yarnFlags "$@"; }'';
 
   npmFlagsYarn  = [ "--offline" "--script-shell=${shellWrap}/bin/npm-shell-wrap.sh" ];
-  npmFlagsNpm   = [ "--cache=./npm-cache" "--nodedir=${_nodejs}" ] + npmFlagsYarn;
+  npmFlagsNpm   = [ "--cache=./npm-cache" "--nodedir=${_nodejs}" ] ++ npmFlagsYarn;
 
   commonEnv = {
     XDG_CONFIG_DIRS     = ".";


### PR DESCRIPTION
Without this change the following error occurs:
```
error: cannot coerce a list to a string, at /nix/store/4f76ih1vlnhcxb1603gvnqwqhssybzy3-source/default.nix:58:19
```