### PR TITLE
Use cleanSourceWith to avoid rebuilding node_modules

### DIFF
--- a/tests/buildNpmPackage/default.nix
+++ b/tests/buildNpmPackage/default.nix
@@ -1,8 +1,10 @@
 { pkgs, npm-buildpackage }:
 
 npm-buildpackage.buildNpmPackage {
-  packageJson = ./package.json;
-  packageLockJson = ./package-lock.json;
-  src = builtins.filterSource (path: type: baseNameOf path != "node_modules" && baseNameOf path != "out") ./.;
+  src = pkgs.lib.cleanSourceWith {
+    name = "simple-test-source";
+    src = ./.;
+    filter = path: type: baseNameOf path != "node_modules" && baseNameOf path != "out";
+  };
   npmBuild = "npm run build";
 }


### PR DESCRIPTION
Makes mkNodeModules depend only on package.json and package-lock.json files
without making the user specify paths to them explicitly