### PR TITLE
do not run top-level lifecycle scripts in node_module generation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -176,7 +176,7 @@ in rec {
 
       configurePhase = ''
         patchShebangs .
-        cp -r ${nodeModules}/node_modules ./node_modules
+        cp --reflink=auto -r ${nodeModules}/node_modules ./node_modules
         chmod -R u+w ./node_modules
       '';
 


### PR DESCRIPTION
Packages can contain [lifecycle scripts](https://docs.npmjs.com/misc/scripts), that `npm ci` will run during `node_module` generation. Since we are not building the package at that stage, that would be wrong. Let's strip them out of the `package.json` in this phase :).

The aim is that users of this repo should be able to use `npm pack` to produce the same output that we do (but packed in a tarball). Running the lifecycle scripts during our build sounds like a decent idea, since that is what the `npm ci && npm prune &&  npm pack` workflow would do outside of nix.

Fixes #12. This also means that it should not require any changes to the projects where it is used.