### PR TITLE
Handle file: dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,11 @@ with stdenv.lib; let
 
   cacheInput = oFile: iFile: writeText oFile (toJSON (listToAttrs (depToFetch iFile)));
 
+  dirOfLocal = { version }:
+    builtins.head (builtins.match "file:(.*)" version);
+
+  isLocal = dep: dep ? version && (! isNull (builtins.match "file:.*" dep.version));
+
   patchShebangs = writeShellScriptBin "patchShebangs.sh" ''
     set -e
     source ${stdenv}/setup
@@ -90,6 +95,8 @@ with stdenv.lib; let
 
   commonBuildInputs = [ _nodejs makeWrapper ];  # TODO: git?
 
+  normalizeName = builtins.replaceStrings [ "@" "." "/" ] [ "_" "_" "_" ];
+
   # unpack the .tgz into output directory and add npm wrapper
   # TODO: "cd $out" vs NIX_NPM_BUILDPACKAGE_OUT=$out?
   untarAndWrap = name: cmds: ''
@@ -117,34 +124,41 @@ with stdenv.lib; let
 in rec {
   mkNodeModules = { src, extraEnvVars ? {} }:
     let
+      localDeps = map dirOfLocal (builtins.filter isLocal (builtins.attrValues (lock.dependencies)));
       # filter out everything except package.json and package-lock.json if possible
       # allows to avoid rebuilding node_modules if these two files didn't change
       filteredSrc =
         let
           origSrc = if src ? _isLibCleanSourceWith then src.origSrc else src;
           getRelativePath = path: removePrefix (toString origSrc + "/") path;
-          usedPaths = [ "package.json" "package-lock.json" ];
-          cleanedSource = cleanSourceWith {
-            src = src;
-            filter = path: type: elem (getRelativePath path) usedPaths;
-          };
+          usedPaths = [ "package.json" "package-lock.json" ]
+            ++ localDeps;
+          dirOfRec = x: if dirOf x == "." || dirOf x == "/" then [x] else ([x] ++ dirOfRec (dirOf x));
+          usedPathsRec = builtins.concatMap dirOfRec usedPaths;
+          cleanedSource = builtins.filterSource (
+            path: type: any (x: elem x usedPathsRec) (dirOfRec (getRelativePath path))
+          ) src;
         in if canCleanSource src then cleanedSource else src;
 
-      packageJson = filteredSrc + "/package.json";
-      packageLockJson = filteredSrc + "/package-lock.json";
+      peerDependencies = map (localDep: mkNodeModules { inherit extraEnvVars; src = src + ("/" + localDep); }) localDeps;
+
+      packageJson = src + "/package.json";
+      packageLockJson = src + "/package-lock.json";
       info = fromJSON (readFile packageJson);
       lock = fromJSON (readFile packageLockJson);
     in stdenv.mkDerivation ({
-      name = "${info.name}-${info.version}-node-modules";
+      name = "${normalizeName info.name}-node-modules-${info.version}";
 
       buildInputs = [ _nodejs jq ];
 
+      src = filteredSrc;
+
       npmFlags = npmFlagsNpm;
-      buildCommand = ''
+
+      phases = [ "unpackPhase" "buildPhase" ];
+      buildPhase = ''
         # do not run the toplevel lifecycle scripts, we only do dependencies
         jq '.scripts={}' ${packageJson} > ./package.json
-        cp ${packageLockJson} ./package-lock.json
-
         echo 'building npm cache'
         chmod u+w ./package-lock.json
         NODE_PATH=${npmModules} node ${./mknpmcache.js} ${cacheInput "npm-cache-input.json" lock}
@@ -152,9 +166,10 @@ in rec {
         echo 'building node_modules'
         npm $npmFlags ci
         patchShebangs ./node_modules/
+        ${concatMapStringsSep "\n" (dep: "cp -r ${dep}/node_modules/* node_modules") peerDependencies}
 
         mkdir $out
-        mv ./node_modules $out/
+        cp -r ./node_modules $out/
       '';
     } // extraEnvVars);
 


### PR DESCRIPTION
Ligo's website uses a `file:` dependency syntax in `package.json`. We need to handle that. It turned out to be pretty simple really.