### PR TITLE
Set $HOME to a tmpdir to fix build on multi-user nix installations

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -147,9 +147,10 @@ in rec {
         # when you run `npm install` or `npm prune`) and will succeed
         # if you have a single-user nix installation (because / is
         # writable in this case), causing different behavior for
-        # single-user and multi-user nix. Create read-only $HOME to
-        # prevent it
-        mkdir -p --mode=a-w "$HOME"
+        # single-user and multi-user nix. Set $HOME to a read-only
+        # directory to fix it
+        export HOME=$(mktemp -d)
+        chmod a-w "$HOME"
 
         # do not run the toplevel lifecycle scripts, we only do dependencies
         jq '.scripts={}' ${packageJson} > ./package.json
@@ -185,7 +186,8 @@ in rec {
       inherit name;
 
       configurePhase = ''
-        mkdir -p --mode=a-w "$HOME"
+        export HOME=$(mktemp -d)
+        chmod a-w "$HOME"
 
         patchShebangs .
         cp --reflink=auto -r ${nodeModules}/node_modules ./node_modules


### PR DESCRIPTION
Problem: creating `$HOME` directory fails in sandboxed builds on
multi-user nix installations because `/` is not writable

Solution: set `$HOME` to a temporary directory, so it will work in both
multi-user and single-user nix, as well as in non-sandboxed builds