### PR TITLE
Fix build behavior when node_modules directory exists in the source

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -187,7 +187,13 @@ in rec {
       configurePhase = ''
         mkdir -p --mode=a-w "$HOME"
 
+        if [[ -e ./node_modules ]]; then
+          echo 'WARNING: node_modules directory already exists, removing it'
+          rm -rf ./node_modules
+        fi
+
         patchShebangs .
+
         cp --reflink=auto -r ${nodeModules}/node_modules ./node_modules
         chmod -R u+w ./node_modules
       '';


### PR DESCRIPTION
Problem: if node_modules directory exists in the source, the builder
will copy new node_modules directory inside the old one instead of
replacing it

Solution: remove existing node_modules directory and warn the user about
it being replaced

Fixes #19