### PR TITLE
Fix path to package.json/package-lock.json when using subdirectory

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -142,8 +142,8 @@ with lib; let
 in rec {
   mkNodeModules = { src, packageOverrides, extraEnvVars ? {}, pname, version }:
     let
-      packageJson = src + /package.json;
-      packageLockJson = src + /package-lock.json;
+      packageJson = src + "/package.json";
+      packageLockJson = src + "/package-lock.json";
       info = fromJSON (readFile packageJson);
       lock = fromJSON (readFile packageLockJson);
     in stdenv.mkDerivation ({
@@ -191,7 +191,7 @@ in rec {
     ...
   }:
     let
-      info = fromJSON (readFile (src + /package.json));
+      info = fromJSON (readFile (src + "/package.json"));
       pname = info.name or "unknown-node-package";
       version = info.version or "unknown";
       nodeModules = mkNodeModules { inherit src packageOverrides extraEnvVars pname version; };


### PR DESCRIPTION
Before this change, you could not do something like this:
```nix
let
  githubSrc = pkgs.fetchFromGitHub {
    owner = "im2nguyen";
    repo = "rover";
    rev = "v0.2.1";
    sha256 = "sha256-vyCgTbUE8IkuBxQR8mib6XybvcGgu2Frjo4Yv2xn4/A=";
  };
in pkgs.mkNodeModules { pname = "something"; version = "1.0"; src = "${githubSrc}/ui"; }
```

After this change it is possible. I have double-checked that the result is still a path. But for some reason a derivation based path does not like adding several paths when using it together with `readFile`. E.g. `githubSrc + /ui + /package.json` does not work, while `githubSrc + /ui/package.json` does. However, `githubSrc + /ui + "/package.json"` does work.