### PR TITLE
copy deps folder

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -123,6 +123,9 @@ in rec {
         # do not run the toplevel lifecycle scripts, we only do dependencies
         cp ${toFile "package.json" (builtins.toJSON (info // { scripts = { }; }))} ./package.json
         cp ${toFile "package-lock.json" (builtins.toJSON lock)} ./package-lock.json
+        if [ -d "${src}/deps" ]; then
+          cp -r ${src}/deps .
+        fi
 
         echo 'building npm cache'
         chmod u+w ./package-lock.json


### PR DESCRIPTION
dealing with package local dependencies can be a hassle.
The solution here is to force package local dependencies
to be in the deps folder. This likely will require some
massaging of the package-lock.json; however it's an ok
tradeoff to me between auto-detection complexity and
offering an escape hatch for local dependencies.

NB: Yes this is an escape hatch hack, but maybe it's a
       compromise until #18 is solved? 