### PR TITLE
Make $HOME writable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -108,17 +108,10 @@ in rec {
       npm_config_offline = true;
       npm_config_script_shell = "${shellWrap}/bin/npm-shell-wrap.sh";
       npm_config_update_notifier = false;
+      npm_config_nodedir = "${nodejs}";
 
       buildCommand = ''
-        # Inside nix-build sandbox $HOME points to a non-existing
-        # directory, but npm may try to create this directory (e.g.
-        # when you run `npm install` or `npm prune`) and will succeed
-        # if you have a single-user nix installation (because / is
-        # writable in this case), causing different behavior for
-        # single-user and multi-user nix. Set $HOME to a read-only
-        # directory to fix it
         export HOME=$(mktemp -d)
-        chmod a-w "$HOME"
 
         # do not run the toplevel lifecycle scripts, we only do dependencies
         cp ${toFile "package.json" (builtins.toJSON (info // { scripts = { }; }))} ./package.json


### PR DESCRIPTION
There is of course a 7 line warning explaining why it isn't writable but I guess it went over my head so I tried making it writable anyway, wouldn't using an `mktemp` directory already avoid the issues/differences between multi-user and single-user Nix anyway without making it unwritable?

Making this writable resolves issues with `node-gyp`, which wants to re-download things from the internet during the build process if it can't find things in `$HOME`, there's _probably_ some weird env vars to work around this, but this seemed like the simplest path to take (and I have this done elsewhere too).

`npm_config_nodedir` is also something I've seen used previously (at least in pnpm2nix), which supposedly also helps with install scripts wanting to download things when they shouldn't.

There should probably still a comment but I didn't write it myself since I think I don't quite understand the issue.