### PR TITLE
Make npm-cache writable during the build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -167,6 +167,9 @@ in rec {
         runHook preConfigure
         export HOME=$(mktemp -d)
         chmod a-w "$HOME"
+        # npm prune actually installs some packages sometimes
+        cp -RL --no-preserve=mode "${nodeModules}/npm-cache" "$PWD/npm-cache"
+        export npm_config_cache="$PWD/npm-cache"
 
         if [[ -e ./node_modules ]]; then
           echo 'WARNING: node_modules directory already exists, removing it'
@@ -200,8 +203,6 @@ in rec {
       '';
       npm_config_offline = true;
       npm_config_update_notifier = false;
-      # npm prune actually installs some packages sometimes
-      npm_config_cache = "${nodeModules}/npm-cache";
 
       passthru = { inherit nodeModules; };
     } // commonEnv // extraEnvVars


### PR DESCRIPTION
`npm prune` sometimes likes to write to npm-cache. Since the cache is provided in a non-writable location, this might cause errors similar to this:
```
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /nix/store/g424xgwwn1dc564vvp51b9z0j7h49hnv-snarkyjs-0.5.1-node-modules/npm-cache/_cacache/content-v2/sha512/bc
npm ERR! errno -13
npm ERR!
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR!
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1000:100 "/nix/store/g424xgwwn1dc564vvp51b9z0j7h49hnv-snarkyjs-0.5.1-node-modules/npm-cache"
```
Fix this by making npm-cache writable.