### PR TITLE
npm install - include --nodedir flag

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,11 @@ with lib;
 let
   inherit (builtins) fromJSON toJSON split removeAttrs replaceStrings toFile;
 
+  nodeSources = runCommand "node-sources" {} ''
+    tar --no-same-owner --no-same-permissions -xf ${nodejs.src}
+    mv node-* $out
+  '';
+
   depsToFetches = deps: concatMap depToFetch (attrValues deps);
 
   depFetchOwn = { resolved, integrity, name ? null, ... }:
@@ -131,7 +136,8 @@ in rec {
         node ${./mknpmcache.js} ${cacheInput "npm-cache-input.json" lock}
 
         echo 'building node_modules'
-        npm ci
+        npm --nodedir=${nodeSources} ci
+        echo 'patching shebangs'
         patchShebangs ./node_modules/
 
         mkdir $out


### PR DESCRIPTION
A dirt cheap trick from node2nix to allow for node-gyp installations, this unblocked me from node-sqlite3 failures. Would be happy to add sqlite3 into the tests to prove the effectiveness of this change. Open for alternatives for example, adding a nix string parameter to append npm install/ci flags freely.