### PR TITLE
remove symlink resolve and add force flag to copy cache operation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -206,7 +206,7 @@ in rec {
         export HOME=$(mktemp -d)
         chmod a-w "$HOME"
         # npm prune actually installs some packages sometimes
-        cp -fR --no-preserve=mode "${nodeModules}/npm-cache" "$PWD/npm-cache"
+        cp -fR${lib.optionalString (!stdenv.isDarwin) "L"} --no-preserve=mode "${nodeModules}/npm-cache" "$PWD/npm-cache"
 
         export npm_config_cache="$PWD/npm-cache"
 


### PR DESCRIPTION
this could be an darwin specific issue, but after the latest merge I'm unable to build (see my comment here https://github.com/serokell/nix-npm-buildpackage/pull/54#issuecomment-1254908364). But I did also experience the same issue as this PR https://github.com/serokell/nix-npm-buildpackage/pull/54 addresses and was able to make the cache copy operation happy. It seems it wants to copy directories into itself and that sorts of stuff.