### PR TITLE
Inherit 'buildInputs' attribute for 'mkNodeModules'

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -194,7 +194,7 @@ in rec {
     let
       inherit (npmInfo src) pname version;
       nodeModules = mkNodeModules ({
-        inherit src extraEnvVars pname version;
+        inherit src extraEnvVars pname version buildInputs;
       } // extraNodeModulesArgs);
     in
       assert asserts.assertMsg (!(args ? packageOverrides)) "buildNpmPackage-packageOverrides is no longer supported";


### PR DESCRIPTION
Problem: Sometimes 'mkNodeModules' requires some additional dependencies, e.g. 'python'. However, currently, there is no way to provide them.

Solution: Make 'mkNodeModules' invocation inside 'buildNpmPackage' inherit 'buildInputs' attribute.