### PR TITLE
Support dependencies with multiple integrities

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -64,7 +64,7 @@ let
     ++ (depsToFetches dependencies);
 
   cacheInput = oFile: iFile:
-    writeText oFile (toJSON (listToAttrs (depToFetch iFile)));
+    writeText oFile (toJSON (depToFetch iFile));
 
   patchShebangs = writeShellScriptBin "patchShebangs.sh" ''
     set -e

--- a/mknpmcache.js
+++ b/mknpmcache.js
@@ -21,7 +21,7 @@ const nixPkgs = JSON.parse(fs.readFileSync(nixPkgsFile, "utf8"))
 
 async function main(nix, cache) {
     const cache_contains = new Set();
-    const promises = Object.values(nix).map(async function({path: source, integrity}) {
+    const promises = nix.map(async function({ value: { path: source, integrity } }) {
         // check for duplicate entry
         if (cache_contains.has(integrity)) return;
         cache_contains.add(integrity);

--- a/tests/buildNpmPackage/package-lock.json
+++ b/tests/buildNpmPackage/package-lock.json
@@ -1974,7 +1974,7 @@
     "node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -5717,7 +5717,7 @@
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }


### PR DESCRIPTION
As discovered in issue #58 and probably elsewhere as well. There is a case where multiple hashing algorithms for the same dependency (same resolved key) will break the cache. The current implementation uses `listToAttrs` with the resolved as key causing one of the entries to get lost and therefore when the cache is being resolved it will fail to find the cache entry.

This removes the attribute set and just writes the full list to the `npm-cache-input.json`. Then updates the `./mknpmcache.js` to work with this new structure.

I also changed a random dependency (`kind-of-3.2.2` dependency of `is-number`) that was occurring multiple times in the lock-file of the `buildNpmPackage` test to use sha1 and sha512 to catch this error and avoid regressions.

This was achieved by finding a package resolved that occurs multiple times, change one of them, download the file and create a sha1 integrity hash and update this:
```
$ curl -O https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz
$ sha1sum kind-of-3.2.2.tgz
31ea21a734bab9bbb0f32466d893aea51e4a3c64  kind-of-3.2.2.tgz
$ nix hash to-sri --type sha1 31ea21a734bab9bbb0f32466d893aea51e4a3c64
sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
```

```patch
index ceec7aa..29104f3 100644
--- a/tests/buildNpmPackage/package-lock.json
+++ b/tests/buildNpmPackage/package-lock.json
@@ -1974,7 +1974,7 @@
     "node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -5717,7 +5717,7 @@
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }

```