### PR TITLE
Don't ln -s /tmp to node_modules

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -176,10 +176,6 @@ in rec {
         mv ./node_modules $out/
         # add npm-cache because npm prune wants to change some pkgs
         mv ./npm-cache $out/
-        # npm wants to write to this cache
-        rm -rf $out/npm-cache/{_cacache/tmp,_locks}
-        ln -s /tmp $out/npm-cache/_cacache/tmp
-        ln -s /tmp $out/npm-cache/_locks
       '';
     } // extraEnvVars);
 


### PR DESCRIPTION
This breaks builds on macOS and unsandboxed Linux. Besides, it's
completely pointless after c34d1e19fb5adaa4c2de6ed3dbb620c9981f2f30.
